### PR TITLE
Fix error embed colors

### DIFF
--- a/src/components/modals/verify-email.js
+++ b/src/components/modals/verify-email.js
@@ -19,9 +19,9 @@ module.exports = {
             )
         ) {
             const embed = new EmbedBuilder()
-                .setColor(0x0f4a00)
+                .setColor(0x9c0b0b)
                 .setDescription(
-                    ':x:  Please provide a student wintec email address, or contact a moderator.'
+                    ':x:  Please provide a valid wintec email address, or contact a moderator.'
                 );
 
             await interaction.reply({ embeds: [embed] });
@@ -138,6 +138,7 @@ module.exports = {
                 embed.setDescription(
                     ':x:  Uh oh, wrong code! Please run /verify again to get a new code.'
                 );
+                embed.setColor(0x9c0b0b)
                 interaction.followUp({ embeds: [embed] });
             }
         });
@@ -153,6 +154,7 @@ module.exports = {
                 embed.setDescription(
                     ':x:  No code detected. Code expired. Run /verify again to get a new code.'
                 );
+                embed.setColor(0x9c0b0b)
                 interaction.followUp({ embeds: [embed] });
             }
         });


### PR DESCRIPTION
On branch fix-message-colors
Changes to be committed:
	modified:   src/components/modals/verify-email.js

Effective changes:
- Changed the color of embeds to red if they are intended to convey an error
- Modified text of verify-email error when submitting an invalid email