### PR TITLE
Add dynamic help command

### DIFF
--- a/src/commands/utility/help.js
+++ b/src/commands/utility/help.js
@@ -1,10 +1,45 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
 
 module.exports = {
     data: new SlashCommandBuilder()
-        .setName('help')
-        .setDescription('Displays all commands.'),
+        .setName("help")
+        .setDescription("Displays all commands."),
     async execute(interaction) {
-        await interaction.reply(`Still in development!`);
+        const client = interaction.client;
+        const commandArray = client.commandArray;
+
+        // Create an embed to display the help message
+        const embed = new EmbedBuilder()
+            .setColor(0x0f4a00)
+            .setTitle("Commands")
+            .setDescription("Here are all available commands:");
+
+        // for (const command of commandArray) {
+        //     embed.addFields({ name: command.name, value: command.description });
+        // }
+
+        // Categorize the commands by folders
+        const categorizedCommands = {};
+        for (const commandData of commandArray) {
+            // We wanna capitalize the title of our folder!
+            const folder = commandData.folder || "Uncategorized";
+            const folderTitle =
+                folder.charAt(0).toUpperCase() + folder.slice(1);
+            if (!categorizedCommands[folderTitle]) {
+                categorizedCommands[folderTitle] = [];
+            }
+            categorizedCommands[folderTitle].push(commandData);
+        }
+
+        // Add fields to the embed for each category
+        for (const folderTitle in categorizedCommands) {
+            const commands = categorizedCommands[folderTitle];
+            const commandList = commands
+                .map((cmd) => `/${cmd.name} - ${cmd.description}`)
+                .join("\n");
+            embed.addFields({ name: folderTitle, value: commandList });
+        }
+
+        await interaction.reply({ embeds: [embed] });
     },
 };

--- a/src/commands/utility/server.js
+++ b/src/commands/utility/server.js
@@ -1,9 +1,9 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
 
 module.exports = {
     data: new SlashCommandBuilder()
-        .setName('server')
-        .setDescription('Provides information about the server.'),
+        .setName("server")
+        .setDescription("Provides information about the server."),
     async execute(interaction) {
         const embed = new EmbedBuilder()
             .setColor(0x0f4a00)

--- a/src/handlers/handleCommands.js
+++ b/src/handlers/handleCommands.js
@@ -1,7 +1,7 @@
 /**-------------------------------------------------------
  * *                   INFO
  *   This is the bot command handler. It collects
- *   all the commands and registers them as interactions. 
+ *   all the commands and registers them as interactions.
  *----------------------------------------------------**/
 
 /*------------------ REQUIRES -----------------*/
@@ -20,49 +20,52 @@ const fs = require("node:fs");
  *@return function
  *=============================================**/
 module.exports = (client) => {
-  client.handleCommands = async () => {
-    //* Grab the commands and make them available to the client
-    const commandFolders = fs.readdirSync("./src/commands");
-    for (const folder of commandFolders) {
-      const commandFiles = fs
-        .readdirSync(`./src/commands/${folder}`)
-        .filter((file) => file.endsWith(".js"));
+    client.handleCommands = async () => {
+        //* Grab the commands and make them available to the client
+        const commandFolders = fs.readdirSync("./src/commands");
+        for (const folder of commandFolders) {
+            const commandFiles = fs
+                .readdirSync(`./src/commands/${folder}`)
+                .filter((file) => file.endsWith(".js"));
 
-      const { commands, commandArray } = client;
-      for (const file of commandFiles) {
-        const command = require(`../commands/${folder}/${file}`);
-        //* We need to make sure the command has been set up properly before registering it
-        if ("data" in command && "execute" in command) {
-          commands.set(command.data.name, command);
-          commandArray.push(command.data.toJSON());
-        } else {
-          console.log(
-            chalk.red(
-              `[Command] The command at ${$folder}/${file} is missing a required "data" or "execute" property. Skipping command.`
-            )
-          );
+            const { commands, commandArray } = client;
+            for (const file of commandFiles) {
+                const command = require(`../commands/${folder}/${file}`);
+                //* We need to make sure the command has been set up properly before registering it
+                if ("data" in command && "execute" in command) {
+                    command.data.folder = folder;
+                    commands.set(command.data.name, command);
+                    commandArray.push(command.data.toJSON());
+                } else {
+                    console.log(
+                        chalk.red(
+                            `[Command] The command at ${$folder}/${file} is missing a required "data" or "execute" property. Skipping command.`
+                        )
+                    );
+                }
+            }
         }
-      }
-    }
 
-    //* Now we get to actually register the commands as interactions to be used by users.
-    const clientID = process.env.CLIENT_ID;
-    const guildId = process.env.GUILD_ID;
-    const rest = new REST({ version: "9" }).setToken(process.env.TOKEN);
-    try {
-      console.log(
-        chalk.cyan("[Command] Started refreshing slash (/) commands...")
-      );
+        //* Now we get to actually register the commands as interactions to be used by users.
+        const clientID = process.env.CLIENT_ID;
+        const guildId = process.env.GUILD_ID;
+        const rest = new REST({ version: "9" }).setToken(process.env.TOKEN);
+        try {
+            console.log(
+                chalk.cyan("[Command] Started refreshing slash (/) commands...")
+            );
 
-      await rest.put(Routes.applicationGuildCommands(clientID, guildId), {
-        body: client.commandArray,
-      });
-    } catch (error) {
-      console.error(error);
-    } finally {
-      console.log(
-        chalk.green("[Command] Slash (/) commands successfully registered")
-      );
-    }
-  };
+            await rest.put(Routes.applicationGuildCommands(clientID, guildId), {
+                body: client.commandArray,
+            });
+        } catch (error) {
+            console.error(error);
+        } finally {
+            console.log(
+                chalk.green(
+                    "[Command] Slash (/) commands successfully registered"
+                )
+            );
+        }
+    };
 };


### PR DESCRIPTION
On branch main
Changes to be committed:
	modified:   src/commands/utility/help.js
	modified:   src/commands/utility/server.js
	modified:   src/handlers/handleCommands.js

Effective changes:
- Command handler now also posts "folder" data to the client, allowing us to categorize commands
- Help command reads the clients command array to dynamically generate output. No more hardcoding!
- Prettier changed some formatting and I can't be bothered fixing it. Cope.

Resolves #38