### PR TITLE
Fix leaderboard, add caching

### DIFF
--- a/src/commands/fun/leaderboard.js
+++ b/src/commands/fun/leaderboard.js
@@ -1,32 +1,45 @@
 // Slash command to display a leaderboard of wizard points
 // Import necessary modules from Discord.js library
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const Balance = require('../../schemas/balance');
+const { SlashCommandBuilder, EmbedBuilder } = require("discord.js");
+const chalk = require("chalk");
+const Balance = require("../../schemas/balance");
 
 module.exports = {
     data: new SlashCommandBuilder()
-        .setName('leaderboard')
-        .setDescription('Gives the amount of points a user has!'),
-    async execute(interaction, client) {
+        .setName("leaderboard")
+        .setDescription("Gives the amount of points a user has!"),
+    async execute(interaction) {
         Balance.find()
-        .sort({balance: -1})
-        .limit(10)
-        .then(leaderboard => {
-            const embed = new EmbedBuilder()
-                .setColor(0x0f4a00)
-                .setTitle('Wizard Point Leaderboard');
-            let position = 1;
+            .sort({ balance: -1 })
+            .limit(10)
+            .then(async (leaderboard) => {
+                const embed = new EmbedBuilder()
+                    .setColor(0x0f4a00)
+                    .setTitle("Wizard Point Leaderboard");
+                let position = 1;
 
-            for (record of leaderboard) {
-                const member = client.users.cache.get(record.userId);
-                const memberName = member.username;
-                embed.addFields({ name:`#${String(position)} @${memberName}`, value:`${String(record.balance)} points` })
-                position++;
-            }
+                for (record of leaderboard) {
+                    const member = await interaction.guild.members
+                        .fetch(record.userId)
+                        .catch((error) => {
+                            console.log(
+                                chalk.red(
+                                    `[API] Cannot fetch user ID ${record.userID}! No longer in server. Error code: ${error.code}`
+                                )
+                            );
+                        });
+                    // make sure user is still in server
+                    const memberName = member?.user?.username || 'Unknown User';
+                    if (memberName != 'Unknown User') {
+                        embed.addFields({
+                            name: `#${String(position)} @${memberName}`,
+                            value: `${String(record.balance)} points`,
+                        });
+                    }
+                    position++;
+                }
 
-            interaction.reply({ embeds: [embed]});
-
-        });
-
+                interaction.reply({ embeds: [embed] });
+            });
     },
 };

--- a/src/events/client/ready.js
+++ b/src/events/client/ready.js
@@ -6,5 +6,12 @@ module.exports = {
     once: true,
     async execute(client) {
         console.log(chalk.green(`[Client] Logged in as @${client.user.username}`));
+
+        const guilds = client.guilds.cache.map(guild => guild.id);
+        for (const id of guilds) {
+            const guild = await client.guilds.fetch(id);
+            const members = await guild.members.fetch();
+            console.log(chalk.green(`[Cache] Cache for guild ${id} built!`));
+        }
     },
 };


### PR DESCRIPTION
Changes to be committed:
	modified:   src/commands/fun/leaderboard.js
	modified:   src/events/client/ready.js

Effective changes:
    - Fixed issue where bot would crash while searching for user that isn't in guild due to difference between mongo db and discord guild
    - Bot now caches all members on startup