### PR TITLE
Fix leaderboard skipping users

### DIFF
--- a/src/commands/fun/leaderboard.js
+++ b/src/commands/fun/leaderboard.js
@@ -35,8 +35,8 @@ module.exports = {
                             name: `#${String(position)} @${memberName}`,
                             value: `${String(record.balance)} points`,
                         });
+                        position++;
                     }
-                    position++;
                 }
 
                 interaction.reply({ embeds: [embed] });


### PR DESCRIPTION
Changes to be committed:
	modified:   src/commands/fun/leaderboard.js

Effective changes:
    - moved the position change (`position++;`) to be inside the if statement that checks whether a user was found
      this has fixed the issue of numbers being skipped in the leaderboard. Resolves #44 